### PR TITLE
Preferences displayed on map

### DIFF
--- a/components/MapContainer.js
+++ b/components/MapContainer.js
@@ -8,7 +8,8 @@ For basic mapping functionality on rcmapp we would mostly need to change the fet
 method on MapContainer so that it retrieves data from our database.
 */
 import React from 'react';
-import {Map, InfoWindow, Marker, GoogleApiWrapper} from 'google-maps-react';
+import {Map, Marker, GoogleApiWrapper} from 'google-maps-react';
+import {InfoWindow} from "./stateless/CustomInfoWindow"
 
 const API_KEY = process.env.GOOGLE_MAPS_PLACES_API_KEY
 
@@ -100,6 +101,7 @@ export class MapContainer extends React.Component {
                         key={key}
                         title={item.user.firstName + " " + item.user.lastName}
                         name={item.user.firstName + " " + item.user.lastName}
+                        user={item.user}
                         position={{lat: item.latitude, lng: item.longitude}}
                         onClick={this.onMarkerClick}
                          />

--- a/components/stateless/CustomInfoWindow.js
+++ b/components/stateless/CustomInfoWindow.js
@@ -97,7 +97,7 @@ export class InfoWindow extends React.Component {
             '<ul>' +
                 '<li>Coffee: ' + user.coffee + '</li>' +
                 '<li>Stay: ' + user.stay + '</li>' +
-                '<li>Milk: ' + user.roomate + '</li>' +
+                '<li>Roomate: ' + user.roomate + '</li>' +
             '</ul>'+
             '</h2>' +
             '<p>Attribution: Uluru, <a href="https://en.wikipedia.org/w/index.php?title=Uluru&oldid=297882194">'+

--- a/components/stateless/CustomInfoWindow.js
+++ b/components/stateless/CustomInfoWindow.js
@@ -89,20 +89,17 @@ export class InfoWindow extends React.Component {
         '<div id="content">'+
             '<div id="siteNotice">'+
             '</div>'+
-            '<h1 id="firstHeading" class="firstHeading">' + 
+            '<h2 id="firstHeading" class="firstHeading">' + 
             user.firstName + " " + user.lastName +
-            '</h1>'+
+            '</h2>'+
             '<div id="bodyContent">'+
-            '<h2>' +
             '<ul>' +
                 '<li>Coffee: ' + user.coffee + '</li>' +
                 '<li>Stay: ' + user.stay + '</li>' +
                 '<li>Roomate: ' + user.roomate + '</li>' +
             '</ul>'+
-            '</h2>' +
-            '<p>Attribution: Uluru, <a href="https://en.wikipedia.org/w/index.php?title=Uluru&oldid=297882194">'+
-            'https://en.wikipedia.org/w/index.php?title=Uluru</a> '+
-            '(last visited June 22, 2009).</p>'+
+            '<p><a href="https://www.recurse.com/directory?q=' + user.email + '">'+
+            'Directory</a> </p>'+
             '</div>'+
             '</div>'
     );

--- a/components/stateless/CustomInfoWindow.js
+++ b/components/stateless/CustomInfoWindow.js
@@ -1,0 +1,141 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import ReactDOM from 'react-dom'
+import ReactDOMServer from 'react-dom/server'
+
+export class InfoWindow extends React.Component {
+
+  componentDidMount() {
+    this.renderInfoWindow();
+  }
+
+  componentDidUpdate(prevProps) {
+    const {google, map} = this.props;
+
+    if (!google || !map) {
+      return;
+    }
+
+    if (map !== prevProps.map) {
+      this.renderInfoWindow();
+    }
+
+    if (this.props.position !== prevProps.position) {
+      this.updatePosition();
+    }
+
+    if (this.props.children !== prevProps.children) {
+      this.updateContent();
+    }
+
+    if ((this.props.visible !== prevProps.visible ||
+        this.props.marker !== prevProps.marker ||
+        this.props.position !== prevProps.position)) {
+        this.props.visible ?
+          this.openWindow() :
+          this.closeWindow();
+    }
+  }
+
+    renderInfoWindow() {
+        const {
+        map,
+        google,
+        mapCenter,
+        ...props
+        } = this.props;
+
+        if (!google || !google.maps) {
+            return;
+        }
+
+        const iw = this.infowindow = new google.maps.InfoWindow({
+            content: ""
+        });
+
+        google.maps.event
+        .addListener(iw, 'closeclick', this.onClose.bind(this))
+        google.maps.event
+        .addListener(iw, 'domready', this.onOpen.bind(this));
+    }
+
+  onOpen() {
+    if (this.props.onOpen) {
+      this.props.onOpen();
+    }
+  }
+
+  onClose() {
+    if (this.props.onClose) {
+      this.props.onClose();
+    }
+  }
+
+  openWindow() {
+    this.infowindow.open(this.props.map, this.props.marker);
+  }
+
+  updatePosition() {
+    let pos = this.props.position;
+    if (!(pos instanceof google.maps.LatLng)) {
+      pos = pos && new google.maps.LatLng(pos.lat, pos.lng);
+    }
+    this.infowindow.setPosition(pos);
+  }
+
+  updateContent() {
+    const user = this.props.marker.user;
+    this.infowindow.setContent(
+        '<div id="content">'+
+            '<div id="siteNotice">'+
+            '</div>'+
+            '<h1 id="firstHeading" class="firstHeading">' + 
+            user.firstName + " " + user.lastName +
+            '</h1>'+
+            '<div id="bodyContent">'+
+            '<h2>' +
+            '<ul>' +
+                '<li>Coffee: ' + user.coffee + '</li>' +
+                '<li>Stay: ' + user.stay + '</li>' +
+                '<li>Milk: ' + user.roomate + '</li>' +
+            '</ul>'+
+            '</h2>' +
+            '<p>Attribution: Uluru, <a href="https://en.wikipedia.org/w/index.php?title=Uluru&oldid=297882194">'+
+            'https://en.wikipedia.org/w/index.php?title=Uluru</a> '+
+            '(last visited June 22, 2009).</p>'+
+            '</div>'+
+            '</div>'
+    );
+  }
+
+  closeWindow() {
+    this.infowindow.close();
+  }
+
+  renderChildren() {
+    const {children} = this.props;
+    return ReactDOMServer.renderToString(children);
+  }
+
+  render() {
+    return null;
+  }
+}
+
+InfoWindow.propTypes = {
+  children: PropTypes.element.isRequired,
+  map: PropTypes.object,
+  marker: PropTypes.object,
+  position: PropTypes.object,
+  visible: PropTypes.bool,
+
+  // callbacks
+  onClose: PropTypes.func,
+  onOpen: PropTypes.func
+}
+
+InfoWindow.defaultProps = {
+  visible: false
+}
+
+export default InfoWindow

--- a/models.js
+++ b/models.js
@@ -23,6 +23,21 @@ const User = sequelize.define('user', {
     type: Sequelize.STRING,
     allowNull: true,
     defaultValue: null
+  },
+  coffee: {
+    type: Sequelize.BOOLEAN,
+    allowNull: false,
+    defaultValue: false
+  },
+  stay: {
+    type: Sequelize.BOOLEAN,
+    allowNull: false,
+    defaultValue: false
+  },
+  roomate: {
+    type: Sequelize.BOOLEAN,
+    allowNull: false,
+    defaultValue: false
   }
 });
 


### PR DESCRIPTION
Added a new component which modifies the default infowindow from the react google maps library. There is probable a better way to extend using the inheritance system of javascript. 

Also modified user model to include preferences.

Info window now displays these preferences as well as a link to the user in the directory.

This can all be easily changed to show the preferences we want in the format we want. Any arbitrary html can be used to format the info window. 